### PR TITLE
- support-project.org の開発用リポジトリを参照するように設定を変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ target/
 hs_err_pid*
 .idea/
 *.iml
+.classpath
+.project
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
     <url>http://amateras.sourceforge.jp/</url>
   </organization>
   <scm>
-    <connection>scm:git:https://github.com/gitbucket/markedj.git</connection>
-    <developerConnection>scm:git:https://github.com/gitbucket/markedj.git</developerConnection>
-    <url>https://github.com/gitbucket/markedj</url>
+    <connection>scm:git:https://github.com/support-project/markedj.git</connection>
+    <developerConnection>scm:git:https://github.com/support-project/markedj.git</developerConnection>
+    <url>https://github.com/support-project/markedj</url>
   </scm>
   <issueManagement>
     <system>GitHub Issues</system>
@@ -30,9 +30,8 @@
   </issueManagement>
   <repositories>
     <repository>
-      <id>amateras</id>
-      <name>Project Amateras Maven2 Repository</name>
-      <url>http://amateras.sourceforge.jp/mvn/</url>
+      <id>private</id>
+      <url>https://support-project.org/nexus/content/repositories/public/</url>
     </repository>
   </repositories>
   <pluginRepositories>
@@ -52,6 +51,7 @@
   </dependencies>
 
   <build>
+    <!-- 
     <extensions>
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
@@ -59,7 +59,9 @@
         <version>1.0</version>
       </extension>
     </extensions>
+    -->
     <plugins>
+      <!-- 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
@@ -73,6 +75,7 @@
           </execution>
         </executions>
       </plugin>
+      -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
@@ -123,12 +126,12 @@
 
   <distributionManagement>
     <repository>
-      <id>sourceforge.jp</id>
-      <url>scp://shell.sourceforge.jp/home/groups/a/am/amateras/htdocs/mvn/</url>
+      <id>org.support.project-releases</id>
+      <url>https://support-project.org/nexus/content/repositories/releases/</url>
     </repository>
     <snapshotRepository>
-      <id>sourceforge.jp</id>
-      <url>scp://shell.sourceforge.jp/home/groups/a/am/amateras/htdocs/mvn-snapshot/</url>
+      <id>org.support.project-snapshots</id>
+      <url>https://support-project.org/nexus/content/repositories/snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
   

--- a/src/main/java/io/github/gitbucket/markedj/Grammer.java
+++ b/src/main/java/io/github/gitbucket/markedj/Grammer.java
@@ -77,6 +77,7 @@ public class Grammer {
         INLINE_RULES.put("autolink", new FindFirstRule("^<([^ >]+(@|:\\/)[^ >]+)>"));
         INLINE_RULES.put("url", new NoopRule());
         INLINE_RULES.put("tag", new FindFirstRule("^<!--[\\s\\S]*?-->|^<\\/?\\w+(?:\"[^\"]*\"|'[^']*'|[^'\">])*?>"));
+        INLINE_RULES.put("oembed", new FindFirstRule("^\\[oembed\\s(" + HREF + ")\\]"));
         INLINE_RULES.put("link", new FindFirstRule(("^!?\\[(" + INSIDE + ")\\]\\(" + HREF + "\\)")));
         INLINE_RULES.put("reflink", new FindFirstRule(("^!?\\[(" + INSIDE + ")\\]\\s*\\[([^\\]]*)\\]")));
         INLINE_RULES.put("nolink", new FindFirstRule("^!?\\[((?:\\[[^\\]]*\\]|[^\\[\\]])*)\\]"));

--- a/src/main/java/io/github/gitbucket/markedj/InlineLexer.java
+++ b/src/main/java/io/github/gitbucket/markedj/InlineLexer.java
@@ -37,6 +37,16 @@ public class InlineLexer {
                 }
             }
 
+            // oembed
+            {
+                List<String> cap = rules.get("oembed").exec(src);
+                if(!cap.isEmpty()){
+                    src = src.substring(cap.get(0).length());
+                    out.append(renderer.oembed(cap.get(1)));
+                    continue;
+                }
+            }
+
             // autolink
             {
                 List<String> cap = rules.get("autolink").exec(src);

--- a/src/main/java/io/github/gitbucket/markedj/Renderer.java
+++ b/src/main/java/io/github/gitbucket/markedj/Renderer.java
@@ -121,6 +121,10 @@ public class Renderer {
         return "<del>" + text + "</del>";
     }
 
+    public String oembed(String href) {
+        return "<a class=\"oembed\" href=\"" + href + "\">" + href + "</a>";
+    }
+
     public String link(String href, String title, String text){
         if(options.isSanitize()){
             // TODO

--- a/src/test/java/io/github/gitbucket/markedj/MarkedTest.java
+++ b/src/test/java/io/github/gitbucket/markedj/MarkedTest.java
@@ -38,6 +38,12 @@ public class MarkedTest {
 //        Files.write(Paths.get("wikilink.html"), result.getBytes("UTF-8"));
     }
 
+    @Test
+    public void testOembed() throws Exception {
+        String md = Marked.marked("[oembed https://speakerdeck.com/speakerdeck/introduction-to-speakerdeck]", new Options());
+        String result = Marked.marked(md, new Options());
+        assertEquals("<p><a class=\"oembed\" href=\"https://speakerdeck.com/speakerdeck/introduction-to-speakerdeck\">https://speakerdeck.com/speakerdeck/introduction-to-speakerdeck</a></p>\n", result);
+    }
 
     @Test
     public void testAutolink() throws Exception {


### PR DESCRIPTION
- knowledgeの [SpeakerDeckやSlideShareなどのスライドを記事に直接表示したい #116] の対応のため
  Markdjをベースに拡張を施す予定
