### PR TITLE
Fix/amp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.support-project</groupId>
   <artifactId>markedj</artifactId>
   <packaging>jar</packaging>
-  <version>1.4.0</version>
+  <version>1.5.0-SNAPSHOT</version>
   <name>markedj</name>
   <url>https://github.com/gitbucket/markedj</url>
   <description>Fork from gitbucket markedj because knowledge's issue. markedj is JVM port of graceful markdown processor marked.js</description>

--- a/src/main/java/io/github/gitbucket/markedj/Utils.java
+++ b/src/main/java/io/github/gitbucket/markedj/Utils.java
@@ -13,7 +13,7 @@ public class Utils {
         if(!encode){
             html = html.replaceAll("&(?!#?\\w+;)", "&amp;");
         } else {
-            html = html.replace("&", "&amp");
+            html = html.replace("&", "&amp;");
         }
         return html.replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;").replace("'", "&#39;");
     }

--- a/src/test/java/io/github/gitbucket/markedj/ExtendParseTest.java
+++ b/src/test/java/io/github/gitbucket/markedj/ExtendParseTest.java
@@ -61,6 +61,44 @@ public class ExtendParseTest {
         assertEquals(expect, result);
     }
 
+    
+    
+    
+    @Test
+    public void testUNC() throws Exception {
+        Options options = new Options();
+        options.setBreaks(true);
+        options.setLinkTargetBlank(true);
+        String md = "[UNCPathLink](¥¥hoge¥data \"UNCPathLink\")";
+        String result = Marked.marked(md, options);
+        String expect = "<p><a href=\"¥¥hoge¥data\" title=\"UNCPathLink\">UNCPathLink</a></p>\n";
+        assertEquals(expect, result);
+    }
+    
+    @Test
+    public void testFile() throws Exception {
+        Options options = new Options();
+        options.setBreaks(true);
+        options.setLinkTargetBlank(true);
+        String md = "[UNCPathLink](file://hoge/data \"UNCPathLink\")";
+        String result = Marked.marked(md, options);
+        String expect = "<p><a href=\"file://hoge/data\" title=\"UNCPathLink\">UNCPathLink</a></p>\n";
+        assertEquals(expect, result);
+    }
+    
+    
+    @Test
+    public void testSmb() throws Exception {
+        Options options = new Options();
+        options.setBreaks(true);
+        options.setLinkTargetBlank(true);
+        String md = "[UNCPathLink](smb://hoge/data \"UNCPathLink\")";
+        String result = Marked.marked(md, options);
+        String expect = "<p><a href=\"smb://hoge/data\" title=\"UNCPathLink\">UNCPathLink</a></p>\n";
+        assertEquals(expect, result);
+    }
+    
+    
     private String loadResourceAsString(String path) throws IOException {
         InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
         try {

--- a/src/test/java/io/github/gitbucket/markedj/ExtendParseTest.java
+++ b/src/test/java/io/github/gitbucket/markedj/ExtendParseTest.java
@@ -99,6 +99,15 @@ public class ExtendParseTest {
     }
     
     
+    @Test
+    public void testAmp() {
+        String markdown = "```\n&read_data\n```";
+        String result = Marked.marked(markdown);
+        String check = "<pre><code>&amp;read_data\n</code></pre>\n";
+        org.junit.Assert.assertEquals(check, result);
+    }
+    
+    
     private String loadResourceAsString(String path) throws IOException {
         InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
         try {


### PR DESCRIPTION
「&」の置換文字列が「&amp」になっていたので「&amp;」に修正
